### PR TITLE
Fixed wires color codes and added a comment with wiring instructions

### DIFF
--- a/Klipper config/SO3.cfg
+++ b/Klipper config/SO3.cfg
@@ -5,13 +5,24 @@
 #config file version v2.2.2
 #release date: 11.05.2024
 
+# Wiring guide:
+# Put the extruder down laying on the bottom of the motor, so that the front fan is facing up.
+# Look at the connector with the motor in this position, you should have the hotend LED on its left.
+# Starting from the LED (left), the pins are:
+# 1) Hotend LED
+# 2) Extruder Temperature - 100K NTC Generic 3950
+# 3) Filament Unload Button
+# 4) Filament Sensor
+# 5) Filament input light - WS2812B
+# 6) +5V
+# 7) GND
 [board_pins SMARTORBITER3] 
 aliases: ### define here the pins to which the SO board is connected #######
   filament_sensor_pin = PC7,         # BROWN signal shall be connected to a digital I/O pin
-  filament_unload_pin = PC6,         # GREY signal shall be connected to a digital I/O pin
-  RGB_pin = PG8,                     # YELLOW signal shall be connected to a digital I/O pin
-  extruder_temperature_pin = PC1,    # WHITE signal shall be connected to a temperature sensing input pin
-  hotend_lit_pin = PA1,              # ORANGE signal shall be connected to a digital I/O pin
+  filament_unload_pin = PC6,         # YELLOW signal shall be connected to a digital I/O pin
+  RGB_pin = PG8,                     # GRAY signal shall be connected to a digital I/O pin
+  extruder_temperature_pin = PC1,    # RED signal shall be connected to a temperature sensing input pin
+  hotend_lit_pin = PA1,              # BLUE signal shall be connected to a digital I/O pin
   ex_step_pin = PC12,                # Extruder STEP signal to be connected to digital IO pin
   ex_dir_pin = PD1,                  # Extruder DIT signal to be connected to digital IO pin
   ex_en_pin = PD2,                   # Extruder Enable signal to be connected to digital IO pin


### PR DESCRIPTION
Hi, I changed the colors of the wires as reported by @CarVac in the issue #3.
To prevent confusion for those not using the SO3-ToolBoard (like me :) ), I also included a brief comment at the top describing the connector, taking inspiration from the image found in the official SO3 page.
Let me know if it's ok for you and if I should do something with the version number/release date before merging this request.

fixes #3
